### PR TITLE
Add «dist» target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,14 @@ $(BUILD):
 	@[ -d $@ ] || mkdir -p $@
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
+	@rm -rf out/
+	@mkdir -p out/atmosphere/contents/420000000007E51A/flags
+	@touch out/atmosphere/contents/420000000007E51A/flags/boot2.flag
+	@cp $(CURDIR)/toolbox.json out/atmosphere/contents/420000000007E51A/toolbox.json
+	@cp $(CURDIR)/$(TARGET).nsp out/atmosphere/contents/420000000007E51A/exefs.nsp
+
+
+
 #---------------------------------------------------------------------------------
 clean:
 	@echo clean ...
@@ -176,8 +184,15 @@ ifeq ($(strip $(APP_JSON)),)
 else
 	@rm -fr $(BUILD) $(TARGET).nsp $(TARGET).nso $(TARGET).npdm $(TARGET).elf
 endif
+	@rm -rf out/
+	@rm -f $(TARGET).zip
 
+#---------------------------------------------------------------------------------
+dist: all
+	@echo making dist ...
 
+	@rm -f $(TARGET).zip
+	@cd out; zip -r ../$(TARGET).zip ./*; cd ../
 #---------------------------------------------------------------------------------
 else
 .PHONY:	all


### PR DESCRIPTION
Add the new target «dist» which create a zip file on the root of the repo with the files needed to copy at root of console's SD making more easy the installation.

Calling «dist» target also calls the build process.

Also adds the creation of «out» directory on the build process with the files.